### PR TITLE
Mudança no princípio de financiamento

### DIFF
--- a/src/estatuto.md
+++ b/src/estatuto.md
@@ -46,7 +46,7 @@ O **LHC** tem como princípios:
 1.  o acesso livre e universal ao conhecimento gerado sob suas
     premissas;
 2.  o financiamento de suas atividades majoritariamente por seus
-    próprios Associados ou através de doações; e
+    próprios Associados; e
 3.  a garantia da livre iniciativa de seus Associados na proposição e
     execução de projetos individuais ou coletivos.
 


### PR DESCRIPTION
Acredito que o LHC deve ter como princípio básico ser mantido apenas com as contribuições financeiras do associados, para evitar a tentação de sermos "patrocinados" com doações de outras entidades. Assim mantém-se a independência do espaço. Isso não impede de maneira alguma o recebimento de doações.