### PR TITLE
Mudança na eleição do Chefe de Conselho

### DIFF
--- a/src/estatuto.md
+++ b/src/estatuto.md
@@ -658,8 +658,8 @@ Ordinária, por candidatura individual a cada cargo, para mandatos de
     eleições poderá votar em apenas um candidato para cada cargo.
 -   Parágrafo 5º - serão declarados eleitos os 02 (dois) primeiros
     colocados na eleição para cada cargo, exceto Chefe do Conselho.
--   Parágrafo 6º - será declarado eleito Chefe do Conselho
-    o candidato que receber o maior número de votos.
+~~- Parágrafo 6º - será declarado eleito Chefe do Conselho
+    o candidato que receber o maior número de votos.~~
 
 
 Artigo 38º


### PR DESCRIPTION
Na minha opinião, o Chefe de Conselho tem que ser eleito dentro do próprio conselho, não sendo uma atividade da assembleia