### PR TITLE
[RFC] Remove menção a difamação como causa para desassociação

### DIFF
--- a/src/estatuto.md
+++ b/src/estatuto.md
@@ -232,10 +232,9 @@ ou justa causa, sendo esta última cabível nas seguintes hipóteses:
 1.  descumprimento deste Estatuto Social, do Código de Conduta ou do
     Regimento Interno;
 2.  prática de ato ilícito e/ou incompatível com os princípios do **LHC**; 
-3.  difamação do **LHC** ou de seus Associados;
-4.  prática de ato que contrarie decisões de Assembleias, Presidência, 
+3.  prática de ato que contrarie decisões de Assembleias, Presidência, 
     Diretorias e Conselhos;
-5.  não pagamento de 02 (duas) parcelas consecutivas das contribuições
+4.  não pagamento de 02 (duas) parcelas consecutivas das contribuições
     associativas.
 
 -   Parágrafo único - A perda da qualidade de Associado por justa causa


### PR DESCRIPTION
Eu não sou advogado, portanto não tenho ideia se estou falando bobagem,
ainda assim, eu gostaria de iniciar uma discussão sobre uma das
situações previstas para desassociação.  O artigo 14º diz que:

  "A perda da qualidade de Associado dar-se-á por [..] justa causa [..]
   nas seguintes hipóteses:

   [..]

  "3. difamação do LHC ou de seus Associados;

  "Parágrafo único - A perda da qualidade de Associado por justa causa
   será determinada pelo Conselho, cabendo recurso da decisão à
   Assembleia Geral, unicamente convocada para este fim, sendo garantida
   a ampla defesa em todas as instâncias."

Eu tenho impressão que isso pode ser problemático, pois não sei entendo
como o Conselho, por mais bem intencionado, conseguiria julgar um caso
de difamação.  Esse me parece um assunto que exige algum conhecimento
jurídico e eu acredito que não teremos pessoas com esse conhecimento no
Conselho (nem em eventuais Assembleias Gerais).

Será que poderíamos levar esse questionamento de forma explícita para os
advogados que vão revisar o estatuto?